### PR TITLE
Window: Changed window to QWidget

### DIFF
--- a/from_soft_manager/ui/window.py
+++ b/from_soft_manager/ui/window.py
@@ -191,7 +191,7 @@ class SideBarWidget(QtWidgets.QFrame):
         self.set_current_tab(None)
 
 
-class MainWindow(QtWidgets.QDialog):
+class MainWindow(QtWidgets.QWidget):
     def __init__(self, controller: "Controller"):
         super().__init__()
 


### PR DESCRIPTION
## Description
Use `QWidget` instead of `QDialog` for main window to be able to minimize or maximize it.