### PR TITLE
DSR: Fix item id of bottomless box items

### DIFF
--- a/src/parse/DSR/SaveFile.cpp
+++ b/src/parse/DSR/SaveFile.cpp
@@ -274,10 +274,13 @@ namespace fssm::parse::dsr {
 
                 if (invItem.itemId >= 1073741824) {
                     invItem.itemType = 1073741824;
+                    invItem.itemId -= 1073741824;
                 } else if (invItem.itemId >= 536870912) {
                     invItem.itemType = 536870912;
+                    invItem.itemId -= 536870912;
                 } else if (invItem.itemId >= 268435456) {
                     invItem.itemType = 268435456;
+                    invItem.itemId -= 268435456;
                 }
                 fillBaseItem(invItem);
                 ci.bottomlessBoxItems.push_back(invItem);


### PR DESCRIPTION
## Description
UI shows correct items from bottomless box.

## Additional information
Item id and item type are stored as one number for bottomless box items, so it was necessary to decrease item id by item type to make it work in UI.